### PR TITLE
upstage[patch]: enable standard tests

### DIFF
--- a/libs/upstage/tests/integration_tests/test_chat_models_standard.py
+++ b/libs/upstage/tests/integration_tests/test_chat_models_standard.py
@@ -9,7 +9,6 @@ from langchain_standard_tests.integration_tests import ChatModelIntegrationTests
 from langchain_upstage import ChatUpstage
 
 
-@pytest.mark.skip("fix after following openai spec")
 class TestUpstageStandard(ChatModelIntegrationTests):
     @property
     def chat_model_class(self) -> Type[BaseChatModel]:
@@ -20,3 +19,7 @@ class TestUpstageStandard(ChatModelIntegrationTests):
         return {
             "model": "solar-1-mini-chat",
         }
+
+    @pytest.mark.xfail(reason="Not implemented.")
+    def test_usage_metadata_streaming(self, model: BaseChatModel) -> None:
+        super().test_usage_metadata_streaming(model)


### PR DESCRIPTION
Integration tests pass after adding one `xfail`: https://github.com/langchain-ai/langchain-upstage/actions/runs/10837522228

cc @JuHyung-Son let me know if you have any objections.