### PR TITLE
Update Solar Pro Tokenizer

### DIFF
--- a/libs/upstage/langchain_upstage/chat_models.py
+++ b/libs/upstage/langchain_upstage/chat_models.py
@@ -55,7 +55,7 @@ from langchain_upstage.document_parse import UpstageDocumentParseLoader
 
 DOC_PARSING_MODEL = ["solar-pro"]
 SOLAR_TOKENIZERS = {
-    "solar-pro": "upstage/solar-pro-preview-tokenizer",
+    "solar-pro": "upstage/solar-pro-tokenizer",
     "solar-1-mini-chat": "upstage/solar-1-mini-tokenizer",
     "solar-docvision": "upstage/solar-docvision-preview-tokenizer",
 }
@@ -135,8 +135,8 @@ class ChatUpstage(BaseChatOpenAI):
     """openai organization is not supported for upstage."""
     tiktoken_model_name: Optional[str] = None
     """tiktoken is not supported for upstage."""
-    tokenizer_name: Optional[str] = "upstage/solar-pro-preview-tokenizer"
-    """huggingface tokenizer name. Solar tokenizer is opened in huggingface https://huggingface.co/upstage/solar-pro-preview-tokenizer"""
+    tokenizer_name: Optional[str] = "upstage/solar-pro-tokenizer"
+    """huggingface tokenizer name. Solar tokenizer is opened in huggingface https://huggingface.co/upstage/solar-pro-tokenizer"""
 
     @model_validator(mode="after")
     def validate_environment(self) -> Self:


### PR DESCRIPTION
## Description

This PR updates the tokenizer for the upstage `solar-pro` model ([api ref](https://console.upstage.ai/docs/capabilities/chat)) from `upstage/solar-pro-preview-tokenizer` to `upstage/solar-pro-tokenizer` ([huggingface link](https://huggingface.co/upstage/solar-pro-tokenizer)).

The solar-pro model has officially launched, transitioning from the preview version to the official version. Accordingly, this change replaces the preview tokenizer with the tokenizer specifically designed for the official release.