### PR TITLE
update document parse base url & remove fragile test

### DIFF
--- a/libs/upstage/langchain_upstage/document_parse_parsers.py
+++ b/libs/upstage/langchain_upstage/document_parse_parsers.py
@@ -13,7 +13,7 @@ from pypdf.errors import PdfReadError
 logger = logging.getLogger("pypdf")
 logger.setLevel(logging.ERROR)
 
-DOCUMENT_PARSE_BASE_URL = "https://api.upstage.ai/v1/document-ai/document-parse"
+DOCUMENT_PARSE_BASE_URL = "https://api.upstage.ai/v1/document-digitization"
 DEFAULT_NUM_PAGES = 10
 DOCUMENT_PARSE_DEFAULT_MODEL = "document-parse"
 

--- a/libs/upstage/pyproject.toml
+++ b/libs/upstage/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "langchain-upstage"
-version = "0.7.0rc0"
+version = "0.7.0rc1"
 description = "An integration package connecting Upstage and LangChain"
 authors = []
 readme = "README.md"

--- a/libs/upstage/tests/integration_tests/test_document_parse.py
+++ b/libs/upstage/tests/integration_tests/test_document_parse.py
@@ -1,15 +1,6 @@
 from pathlib import Path
-from typing import get_args
-
-import pytest
 
 from langchain_upstage.document_parse import UpstageDocumentParseLoader
-from langchain_upstage.document_parse_parsers import (
-    OCR,
-    Category,
-    OutputFormat,
-    SplitType,
-)
 
 EXAMPLE_PDF_PATH = Path(__file__).parent.parent / "examples/solar.pdf"
 
@@ -24,30 +15,3 @@ def test_file_not_found_error() -> None:
         assert False
     except FileNotFoundError:
         assert True
-
-
-@pytest.mark.parametrize("output_format", get_args(OutputFormat))
-@pytest.mark.parametrize("split", get_args(SplitType))
-@pytest.mark.parametrize("ocr", get_args(OCR))
-@pytest.mark.parametrize("coordinates", [True, False])
-@pytest.mark.parametrize("base64_encoding", ["paragraph"])
-def test_document_parse(
-    output_format: OutputFormat,
-    split: SplitType,
-    ocr: OCR,
-    coordinates: bool,
-    base64_encoding: Category,
-) -> None:
-    loader = UpstageDocumentParseLoader(
-        file_path=EXAMPLE_PDF_PATH,
-        output_format=output_format,
-        split=split,
-        ocr=ocr,
-        coordinates=coordinates,
-        base64_encoding=[base64_encoding],
-    )
-    documents = loader.load()
-    if split == "element":
-        assert len(documents) == 14
-    else:
-        assert len(documents) == 1

--- a/libs/upstage/tests/integration_tests/test_document_parse.py
+++ b/libs/upstage/tests/integration_tests/test_document_parse.py
@@ -48,9 +48,6 @@ def test_document_parse(
     )
     documents = loader.load()
     if split == "element":
-        if ocr == "auto":
-            assert len(documents) == 14
-        else:
-            assert len(documents) == 15
+        assert len(documents) == 14
     else:
         assert len(documents) == 1


### PR DESCRIPTION
## Description:
- Update document parse base url.
  - Before: `https://api.upstage.ai/v1/document-ai/document-parse`
  - Now: `https://api.upstage.ai/v1/document-digitization`
- Remove fragile tests dependent on model outputs.
  - It relies on internal model behaviors instead of verifiable logic.

## Issue: N/A

## Dependencies: N/A

## Twitter handle: N/A