### PR TITLE
[FIX] resolve version conflict issue with langchain-openai  (langchain-openai 버전 충돌 문제 해결)

### DIFF
--- a/libs/upstage/pyproject.toml
+++ b/libs/upstage/pyproject.toml
@@ -15,7 +15,7 @@ python = ">=3.9,<4.0"
 pypdf = "^4.2.0"
 requests = "^2.31.0"
 tokenizers = "^0.20.0"
-langchain-openai = "^0.3"
+langchain-openai = "^0.3,<=0.3.33"
 langchain-core = "^0.3.29"
 
 [tool.poetry.group.test]


### PR DESCRIPTION
Since langchain-openai 0.3.34, they removed `_AllReturnType` type from `langchain_openai.chat_models.base`. 

In this PR, rather than find & fix the root cause, I simply put a restriction for langchain-openai dependencies. I can do that but In order to do that properly I should consider many edge cases. So I wish after this PR maintainers make a fix for this upstream dependency error. 

- [langchain-openai 0.3.33](https://github.com/langchain-ai/langchain/blob/langchain-openai%3D%3D0.3.33/libs/partners/openai/langchain_openai/chat_models/base.py)
- [langchain-openai 0.3.34](https://github.com/langchain-ai/langchain/blob/langchain-openai%3D%3D0.3.34/libs/partners/openai/langchain_openai/chat_models/base.py)

